### PR TITLE
Composer v.2 installation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To install the bindings via [Composer](https://getcomposer.org/), add the follow
     }
   ],
   "require": {
-    "OneSignal/onesignal-php-api": "*@dev"
+    "onesignal/onesignal-php-api": "*@dev"
   }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "onesignal-php-api",
+    "name": "onesignal/onesignal-php-api",
     "version": "1.0.0",
     "description": "A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com",
     "keywords": [


### PR DESCRIPTION
# Description

Added vendor name path in composer "name", changed it to lowercase.

## Details

### Motivation

I was unable to install it on my windows machine

# Testing

Installation works on Windows 10.
Composer version 2.3.10 2022-07-13 15:48:23