### PR TITLE
Add v5.4.0 package updates

### DIFF
--- a/docs/Api/DefaultApi.md
+++ b/docs/Api/DefaultApi.md
@@ -529,12 +529,17 @@ $config = onesignal\client\Configuration::getDefaultConfiguration()
 
 
 $apiInstance = new onesignal\client\Api\DefaultApi(
-    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
-    // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
     $config
 );
-$notification = new \onesignal\client\model\Notification(); // \onesignal\client\model\Notification
+
+$notification = new onesignal\client\Model\Notification();
+$notification->setAppId('YOUR_APP_ID');
+$contents = new onesignal\client\Model\LanguageStringMap();
+$contents->setEn('Hello from OneSignal!');
+$notification->setContents($contents);
+$notification->setIncludeAliases(['external_id' => ['YOUR_USER_EXTERNAL_ID']]);
+$notification->setTargetChannel('push');
 
 try {
     $result = $apiInstance->createNotification($notification);


### PR DESCRIPTION
## Release v5.4.0

### 🚀 Features
- feat(ci): close stale user-api-updates PRs before fan-out
- feat: add flat create-notification doc examples via vendor extension

### 🐛 Bug Fixes
- fix(ruby): remove redundant gem build step from release workflow
- fix(ci): tolerate gh pr close failures during stale PR cleanup
- fix: Rust consumer imports, Python model imports, Java modelPackage in API docs
- fix(ci): drift-mode rerun safety + pre-release range matching

### 📚 Docs
- docs: point partial-release caveat at SDK-4396 (cd.yml scope filter)

### 🔧 Internal
- build(release): bump package versions
- test(ruby): use string outer / symbol inner keys for result.content
- build(ruby): sync release workflow fix
- ci: generate real release notes in downstream PR bodies
- ci: correct release-notes anchor + warn on compareCommits truncation
- ci: add script/bump-version helper
- ci: auto-populate root release PR body via sdk-shared/create-release.yml
- ci: add one-click release orchestrator via sdk-shared/prep-release.yml
- ci: unstage devdist's pre-staged outputs deletions before chore commit
- ci: delegate release version math to node-semver CLI
- ci: enforce lockstep versioning across all client libraries
- ci: add partial-release label bypass + document per-language hotfix flow
- ci: gate release workflow on script/test-<lang> matrix
- ci: pin release test matrix checkouts to rel/<version>
- ci: cut root GitHub Release on every release PR merge
- ci: anchor downstream-links version on commit message, not api.json
- ci: harden downstream-links gate, reconcile bare-version tags, make re-runs idempotent
- ci: auto-transition Linear tickets to Deployed on release
- ci: tighten lint-pr-title.yml to align with sdk-shared conventions
- ci: scope cd.yml fan-out to changed outputs/<lang>/ trees
- ci: address PR #364 review feedback
- ci: support drift-preserving releases (per-library version bumps)
- build: sync generated SDKs and DefaultApi reference docs
- build: refresh DefaultApi.md for Java, Python, and Rust

---
_Generated from [OneSignal/api-client-libraries@bc71af6...8a77f63](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...8a77f63491b3d6c70b21ab49e189efca93ed6833)._