### PR TITLE
docs: add v5.4.0 package updates

### DIFF
--- a/docs/Api/DefaultApi.md
+++ b/docs/Api/DefaultApi.md
@@ -529,12 +529,17 @@ $config = onesignal\client\Configuration::getDefaultConfiguration()
 
 
 $apiInstance = new onesignal\client\Api\DefaultApi(
-    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
-    // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client(),
     $config
 );
-$notification = new \onesignal\client\model\Notification(); // \onesignal\client\model\Notification
+
+$notification = new onesignal\client\Model\Notification();
+$notification->setAppId('YOUR_APP_ID');
+$contents = new onesignal\client\Model\LanguageStringMap();
+$contents->setEn('Hello from OneSignal!');
+$notification->setContents($contents);
+$notification->setIncludeAliases(['external_id' => ['YOUR_USER_EXTERNAL_ID']]);
+$notification->setTargetChannel('push');
 
 try {
     $result = $apiInstance->createNotification($notification);


### PR DESCRIPTION
## Updates
- docs: add flat create-notification doc examples via vendor extension

---
_Generated from [OneSignal/api-client-libraries@bc71af6...35a92b9](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...35a92b9872393d79d8270897b2e134f2b42562b0)._