### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/docs/Model/CreateNotificationSuccessResponse.md
+++ b/docs/Model/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). | [optional]
+**id** | **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly. | [optional]
 **external_id** | **string** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;). | [optional]
 **errors** | **mixed** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional]
 

--- a/lib/helpers/NotificationHelpers.php
+++ b/lib/helpers/NotificationHelpers.php
@@ -74,6 +74,41 @@ class NotificationHelpers
         }
     }
 
+    /**
+     * Whether a POST /notifications 200 response is the "message sent" branch.
+     *
+     * POST /notifications returns 200 in two cases that share the
+     * CreateNotificationSuccessResponse shape: a notification was created
+     * (non-empty id), or none was (empty id, with errors carrying the reason).
+     * Prefer this guard over inspecting id directly.
+     *
+     * @param \onesignal\client\model\CreateNotificationSuccessResponse $response
+     *
+     * @return bool true when a notification was created
+     */
+    public static function isMessageSent($response)
+    {
+        if ($response === null) {
+            return false;
+        }
+        $id = $response->getId();
+        return is_string($id) && $id !== '';
+    }
+
+    /**
+     * Whether a POST /notifications 200 response is the "message not sent"
+     * branch -- no notification was created (id absent or empty); inspect
+     * errors for why.
+     *
+     * @param \onesignal\client\model\CreateNotificationSuccessResponse $response
+     *
+     * @return bool true when no notification was created
+     */
+    public static function isMessageNotSent($response)
+    {
+        return !self::isMessageSent($response);
+    }
+
     private static function headerValue($headers, $name)
     {
         if (!is_array($headers)) {

--- a/lib/model/CreateNotificationSuccessResponse.php
+++ b/lib/model/CreateNotificationSuccessResponse.php
@@ -231,7 +231,7 @@ class CreateNotificationSuccessResponse implements ModelInterface, ArrayAccess, 
     /**
      * Sets id
      *
-     * @param string|null $id Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).
+     * @param string|null $id Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.
      *
      * @return self
      */


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...c73114f](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...c73114f026690637dccea57b21ee6f0a1eca5051)._