### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/docs/Api/DefaultApi.md
+++ b/docs/Api/DefaultApi.md
@@ -2023,7 +2023,7 @@ Name | Type | Description  | Notes
 ## `getNotifications()`
 
 ```php
-getNotifications($app_id, $limit, $offset, $kind): \onesignal\client\model\NotificationSlice
+getNotifications($app_id, $limit, $offset, $kind, $time_offset): \onesignal\client\model\NotificationSlice
 ```
 
 View notifications
@@ -2054,9 +2054,10 @@ $app_id = '00000000-0000-0000-0000-000000000000'; // string | The app ID that yo
 $limit = 10; // int | How many notifications to return.  Max is 50.  Default is 50.
 $offset = 0; // int | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.
 $kind = 0; // int | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only
+$time_offset = '2025-01-01T00:00:00.000Z'; // string | Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned.
 
 try {
-    $result = $apiInstance->getNotifications($app_id, $limit, $offset, $kind);
+    $result = $apiInstance->getNotifications($app_id, $limit, $offset, $kind, $time_offset);
     print_r($result);
 } catch (\onesignal\client\ApiException $e) {
     echo 'Exception when calling DefaultApi->getNotifications: ', $e->getMessage(), PHP_EOL;
@@ -2078,6 +2079,7 @@ Name | Type | Description  | Notes
  **limit** | **int**| How many notifications to return.  Max is 50.  Default is 50. | [optional]
  **offset** | **int**| Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. | [optional]
  **kind** | **int**| Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only | [optional]
+ **time_offset** | **string**| Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. | [optional]
 
 ### Return type
 

--- a/docs/Model/CreateNotificationSuccessResponse.md
+++ b/docs/Model/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). | [optional]
+**id** | **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly. | [optional]
 **external_id** | **string** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;). | [optional]
 **errors** | **mixed** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional]
 

--- a/docs/Model/NotificationSlice.md
+++ b/docs/Model/NotificationSlice.md
@@ -7,6 +7,8 @@ Name | Type | Description | Notes
 **total_count** | **int** |  | [optional]
 **offset** | **int** |  | [optional]
 **limit** | **int** |  | [optional]
+**time_offset** | **string** | The time_offset cursor specified in the request, if any. | [optional]
+**next_time_offset** | **string** | An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating. | [optional]
 **notifications** | [**\onesignal\client\model\NotificationWithMeta[]**](NotificationWithMeta.md) |  | [optional]
 
 [[Back to API list]](https://github.com/OneSignal/onesignal-php-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-php-api)

--- a/lib/api/DefaultApi.php
+++ b/lib/api/DefaultApi.php
@@ -9469,14 +9469,15 @@ class DefaultApi
      * @param  int $limit How many notifications to return.  Max is 50.  Default is 50. (optional)
      * @param  int $offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
      * @param  int $kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only (optional)
+     * @param  string $time_offset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)
      *
      * @throws \onesignal\client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \onesignal\client\model\NotificationSlice|\onesignal\client\model\GenericError|\onesignal\client\model\RateLimitError
      */
-    public function getNotifications($app_id, $limit = null, $offset = null, $kind = null)
+    public function getNotifications($app_id, $limit = null, $offset = null, $kind = null, $time_offset = null)
     {
-        list($response) = $this->getNotificationsWithHttpInfo($app_id, $limit, $offset, $kind);
+        list($response) = $this->getNotificationsWithHttpInfo($app_id, $limit, $offset, $kind, $time_offset);
         return $response;
     }
 
@@ -9489,14 +9490,15 @@ class DefaultApi
      * @param  int $limit How many notifications to return.  Max is 50.  Default is 50. (optional)
      * @param  int $offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
      * @param  int $kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only (optional)
+     * @param  string $time_offset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)
      *
      * @throws \onesignal\client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \onesignal\client\model\NotificationSlice|\onesignal\client\model\GenericError|\onesignal\client\model\RateLimitError, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getNotificationsWithHttpInfo($app_id, $limit = null, $offset = null, $kind = null)
+    public function getNotificationsWithHttpInfo($app_id, $limit = null, $offset = null, $kind = null, $time_offset = null)
     {
-        $request = $this->getNotificationsRequest($app_id, $limit, $offset, $kind);
+        $request = $this->getNotificationsRequest($app_id, $limit, $offset, $kind, $time_offset);
 
         try {
             $options = $this->createHttpClientOption();
@@ -9637,13 +9639,14 @@ class DefaultApi
      * @param  int $limit How many notifications to return.  Max is 50.  Default is 50. (optional)
      * @param  int $offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
      * @param  int $kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only (optional)
+     * @param  string $time_offset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getNotificationsAsync($app_id, $limit = null, $offset = null, $kind = null)
+    public function getNotificationsAsync($app_id, $limit = null, $offset = null, $kind = null, $time_offset = null)
     {
-        return $this->getNotificationsAsyncWithHttpInfo($app_id, $limit, $offset, $kind)
+        return $this->getNotificationsAsyncWithHttpInfo($app_id, $limit, $offset, $kind, $time_offset)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -9660,14 +9663,15 @@ class DefaultApi
      * @param  int $limit How many notifications to return.  Max is 50.  Default is 50. (optional)
      * @param  int $offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
      * @param  int $kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only (optional)
+     * @param  string $time_offset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getNotificationsAsyncWithHttpInfo($app_id, $limit = null, $offset = null, $kind = null)
+    public function getNotificationsAsyncWithHttpInfo($app_id, $limit = null, $offset = null, $kind = null, $time_offset = null)
     {
         $returnType = '\onesignal\client\model\NotificationSlice';
-        $request = $this->getNotificationsRequest($app_id, $limit, $offset, $kind);
+        $request = $this->getNotificationsRequest($app_id, $limit, $offset, $kind, $time_offset);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -9712,11 +9716,12 @@ class DefaultApi
      * @param  int $limit How many notifications to return.  Max is 50.  Default is 50. (optional)
      * @param  int $offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
      * @param  int $kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only (optional)
+     * @param  string $time_offset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getNotificationsRequest($app_id, $limit = null, $offset = null, $kind = null)
+    public function getNotificationsRequest($app_id, $limit = null, $offset = null, $kind = null, $time_offset = null)
     {
         // verify the required parameter 'app_id' is set
         if ($app_id === null || (is_array($app_id) && count($app_id) === 0)) {
@@ -9764,6 +9769,15 @@ class DefaultApi
             $kind,
             'kind', // param base name
             'integer', // openApiType
+            'form', // style
+            true, // explode
+            false // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $time_offset,
+            'time_offset', // param base name
+            'string', // openApiType
             'form', // style
             true, // explode
             false // required

--- a/lib/helpers/NotificationHelpers.php
+++ b/lib/helpers/NotificationHelpers.php
@@ -74,6 +74,41 @@ class NotificationHelpers
         }
     }
 
+    /**
+     * Whether a POST /notifications 200 response is the "message sent" branch.
+     *
+     * POST /notifications returns 200 in two cases that share the
+     * CreateNotificationSuccessResponse shape: a notification was created
+     * (non-empty id), or none was (empty id, with errors carrying the reason).
+     * Prefer this guard over inspecting id directly.
+     *
+     * @param \onesignal\client\model\CreateNotificationSuccessResponse $response
+     *
+     * @return bool true when a notification was created
+     */
+    public static function isMessageSent($response)
+    {
+        if ($response === null) {
+            return false;
+        }
+        $id = $response->getId();
+        return is_string($id) && $id !== '';
+    }
+
+    /**
+     * Whether a POST /notifications 200 response is the "message not sent"
+     * branch -- no notification was created (id absent or empty); inspect
+     * errors for why.
+     *
+     * @param \onesignal\client\model\CreateNotificationSuccessResponse $response
+     *
+     * @return bool true when no notification was created
+     */
+    public static function isMessageNotSent($response)
+    {
+        return !self::isMessageSent($response);
+    }
+
     private static function headerValue($headers, $name)
     {
         if (!is_array($headers)) {

--- a/lib/model/CreateNotificationSuccessResponse.php
+++ b/lib/model/CreateNotificationSuccessResponse.php
@@ -231,7 +231,7 @@ class CreateNotificationSuccessResponse implements ModelInterface, ArrayAccess, 
     /**
      * Sets id
      *
-     * @param string|null $id Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).
+     * @param string|null $id Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.
      *
      * @return self
      */

--- a/lib/model/NotificationSlice.php
+++ b/lib/model/NotificationSlice.php
@@ -63,6 +63,8 @@ class NotificationSlice implements ModelInterface, ArrayAccess, \JsonSerializabl
         'total_count' => 'int',
         'offset' => 'int',
         'limit' => 'int',
+        'time_offset' => 'string',
+        'next_time_offset' => 'string',
         'notifications' => '\onesignal\client\model\NotificationWithMeta[]'
     ];
 
@@ -77,6 +79,8 @@ class NotificationSlice implements ModelInterface, ArrayAccess, \JsonSerializabl
         'total_count' => null,
         'offset' => null,
         'limit' => null,
+        'time_offset' => null,
+        'next_time_offset' => null,
         'notifications' => null
     ];
 
@@ -110,6 +114,8 @@ class NotificationSlice implements ModelInterface, ArrayAccess, \JsonSerializabl
         'total_count' => 'total_count',
         'offset' => 'offset',
         'limit' => 'limit',
+        'time_offset' => 'time_offset',
+        'next_time_offset' => 'next_time_offset',
         'notifications' => 'notifications'
     ];
 
@@ -122,6 +128,8 @@ class NotificationSlice implements ModelInterface, ArrayAccess, \JsonSerializabl
         'total_count' => 'setTotalCount',
         'offset' => 'setOffset',
         'limit' => 'setLimit',
+        'time_offset' => 'setTimeOffset',
+        'next_time_offset' => 'setNextTimeOffset',
         'notifications' => 'setNotifications'
     ];
 
@@ -134,6 +142,8 @@ class NotificationSlice implements ModelInterface, ArrayAccess, \JsonSerializabl
         'total_count' => 'getTotalCount',
         'offset' => 'getOffset',
         'limit' => 'getLimit',
+        'time_offset' => 'getTimeOffset',
+        'next_time_offset' => 'getNextTimeOffset',
         'notifications' => 'getNotifications'
     ];
 
@@ -197,6 +207,8 @@ class NotificationSlice implements ModelInterface, ArrayAccess, \JsonSerializabl
         $this->container['total_count'] = $data['total_count'] ?? null;
         $this->container['offset'] = $data['offset'] ?? null;
         $this->container['limit'] = $data['limit'] ?? null;
+        $this->container['time_offset'] = $data['time_offset'] ?? null;
+        $this->container['next_time_offset'] = $data['next_time_offset'] ?? null;
         $this->container['notifications'] = $data['notifications'] ?? null;
     }
 
@@ -292,6 +304,54 @@ class NotificationSlice implements ModelInterface, ArrayAccess, \JsonSerializabl
     public function setLimit($limit)
     {
         $this->container['limit'] = $limit;
+
+        return $this;
+    }
+
+    /**
+     * Gets time_offset
+     *
+     * @return string|null
+     */
+    public function getTimeOffset()
+    {
+        return $this->container['time_offset'];
+    }
+
+    /**
+     * Sets time_offset
+     *
+     * @param string|null $time_offset The time_offset cursor specified in the request, if any.
+     *
+     * @return self
+     */
+    public function setTimeOffset($time_offset)
+    {
+        $this->container['time_offset'] = $time_offset;
+
+        return $this;
+    }
+
+    /**
+     * Gets next_time_offset
+     *
+     * @return string|null
+     */
+    public function getNextTimeOffset()
+    {
+        return $this->container['next_time_offset'];
+    }
+
+    /**
+     * Sets next_time_offset
+     *
+     * @param string|null $next_time_offset An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.
+     *
+     * @return self
+     */
+    public function setNextTimeOffset($next_time_offset)
+    {
+        $this->container['next_time_offset'] = $next_time_offset;
 
         return $this;
     }


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4776] expose time_offset pagination on get_notifications
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set
- fix: [SDK-4776] append time_offset after kind in get_notifications

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...2907ac8](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...2907ac87ca594fc5aee71ccfab5839f35b6a0f38)._