### PR TITLE
chore: pin conventional-changelog-conventionalcommits to v9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,5 @@ jobs:
               -p @semantic-release/exec \
               -p @semantic-release/git \
               -p @semantic-release/github \
-              -p conventional-changelog-conventionalcommits \
+              -p conventional-changelog-conventionalcommits@9 \
               semantic-release


### PR DESCRIPTION
Pin `conventional-changelog-conventionalcommits` to v9 in `.github/workflows/release.yml`.